### PR TITLE
Feature/multiplayer support

### DIFF
--- a/src/main/java/treechopper/common/PlayerInteract.java
+++ b/src/main/java/treechopper/common/PlayerInteract.java
@@ -1,0 +1,16 @@
+package treechopper.common;
+
+import net.minecraft.util.math.BlockPos;
+
+public class PlayerInteract {
+
+  public BlockPos blockPos; // Interact block position
+  public float logCount;
+  public int axeDurability;
+
+  public PlayerInteract(BlockPos blockPos, float logCount, int axeDurability) {
+    this.blockPos = blockPos;
+    this.logCount = logCount;
+    this.axeDurability = axeDurability;
+  }
+}

--- a/src/main/java/treechopper/common/handler/TreeHandler.java
+++ b/src/main/java/treechopper/common/handler/TreeHandler.java
@@ -131,29 +131,25 @@ public class TreeHandler {
    *   Decay leaves if enabled, sets all leaf blocks to air
    *
    * @param world Minecraft world
-   * @param entityPlayer Player who broke the tree
+   * @param tree Tree to be broken
    */
-  public void destroyTree(World world, PlayerEntity entityPlayer) {
-    if (treeMap.containsKey(entityPlayer.getUniqueID())) {
-      Tree tmpTree = treeMap.get(entityPlayer.getUniqueID());
-
-      for (BlockPos logPos : tmpTree.getLogs()) {
+  public void destroyTree(World world, Tree tree) {
+      for (BlockPos logPos : tree.getLogs()) {
         world.destroyBlock(logPos, true);
         world.setBlockState(logPos, Blocks.AIR.getDefaultState());
       }
 
-      if (Configuration.common.plantSapling.get() && !tmpTree.getLeaves().isEmpty()) {
-        BlockPos tmpPosition = tmpTree.getLeaves().get(tmpTree.getLeavesCount() - 1);
-        plantSapling(world, tmpPosition, tmpTree.getInitialBlockPosition());
+      if (Configuration.common.plantSapling.get() && !tree.getLeaves().isEmpty()) {
+        BlockPos tmpPosition = tree.getLeaves().get(tree.getLeavesCount() - 1);
+        plantSapling(world, tmpPosition, tree.getInitialBlockPosition());
       }
 
       if (Configuration.common.decayLeaves.get()) {
-        for (BlockPos leafPos : tmpTree.getLeaves()) {
+        for (BlockPos leafPos : tree.getLeaves()) {
           world.destroyBlock(leafPos, true);
           world.setBlockState(leafPos, Blocks.AIR.getDefaultState());
         }
       }
-    }
   }
 
   /**

--- a/src/main/java/treechopper/common/handler/TreeHandler.java
+++ b/src/main/java/treechopper/common/handler/TreeHandler.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.event.world.BlockEvent;
 import treechopper.common.config.Configuration;
 import treechopper.common.tree.Tree;
 
@@ -122,6 +123,17 @@ public class TreeHandler {
     tree.insertLog(blockPos);
 
     return true;
+  }
+
+  public void destroyTreeCommonEvent(BlockEvent.BreakEvent breakEvent) {
+    BlockPos blockPos = breakEvent.getPos();
+    Tree tree = analyzeTree((World) breakEvent.getWorld(), blockPos, breakEvent.getPlayer());
+    destroyTree((World) breakEvent.getWorld(), tree);
+
+    if (!breakEvent.getPlayer().isCreative() && breakEvent.getPlayer().getHeldItemMainhand().isDamageable()) {
+      int axeDurability = breakEvent.getPlayer().getHeldItemMainhand().getDamage() + (int)(tree.getLogCount() * 1.5);
+      breakEvent.getPlayer().getHeldItemMainhand().setDamage(axeDurability);
+    }
   }
 
   /**

--- a/src/main/java/treechopper/common/handler/TreeHandler.java
+++ b/src/main/java/treechopper/common/handler/TreeHandler.java
@@ -125,6 +125,13 @@ public class TreeHandler {
     return true;
   }
 
+  /**
+   * Destroy tree has the same logic for client and server but it has to be registered on both. If it is only
+   *   registered on one, it won't work when used in the other.
+   * I don't actually know why that is, I thought single player used a virtual server for its back end.
+   *
+   * @param breakEvent Event that triggers the destroy tree event.
+   */
   public void destroyTreeCommonEvent(BlockEvent.BreakEvent breakEvent) {
     BlockPos blockPos = breakEvent.getPos();
     Tree tree = analyzeTree((World) breakEvent.getWorld(), blockPos, breakEvent.getPlayer());

--- a/src/main/java/treechopper/proxy/CommonProxy.java
+++ b/src/main/java/treechopper/proxy/CommonProxy.java
@@ -13,6 +13,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import treechopper.command.*;
+import treechopper.common.PlayerInteract;
 import treechopper.common.config.Configuration;
 import treechopper.common.handler.TreeHandler;
 import treechopper.core.TreeChopper;
@@ -20,19 +21,6 @@ import treechopper.core.TreeChopper;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
-class PlayerInteract {
-
-  public BlockPos blockPos; // Interact block position
-  public float logCount;
-  public int axeDurability;
-
-  public PlayerInteract(BlockPos blockPos, float logCount, int axeDurability) {
-    this.blockPos = blockPos;
-    this.logCount = logCount;
-    this.axeDurability = axeDurability;
-  }
-}
 
 /**
  * Handles all event bus listeners.  Client side only.

--- a/src/main/java/treechopper/proxy/CommonProxy.java
+++ b/src/main/java/treechopper/proxy/CommonProxy.java
@@ -16,6 +16,7 @@ import treechopper.command.*;
 import treechopper.common.PlayerInteract;
 import treechopper.common.config.Configuration;
 import treechopper.common.handler.TreeHandler;
+import treechopper.common.tree.Tree;
 import treechopper.core.TreeChopper;
 
 import java.util.HashMap;
@@ -110,7 +111,7 @@ public class CommonProxy {
    */
   @SubscribeEvent
   public static void destroyWoodBlock(BlockEvent.BreakEvent breakEvent) {
-
+    treeHandler.destroyTreeCommonEvent(breakEvent);
   }
 
   // Check if the block at @blockPos is an instance of LOGS

--- a/src/main/java/treechopper/proxy/CommonProxy.java
+++ b/src/main/java/treechopper/proxy/CommonProxy.java
@@ -110,18 +110,7 @@ public class CommonProxy {
    */
   @SubscribeEvent
   public static void destroyWoodBlock(BlockEvent.BreakEvent breakEvent) {
-    if (playerData.containsKey(breakEvent.getPlayer().getUniqueID())) {
-      BlockPos blockPos = playerData.get(breakEvent.getPlayer().getUniqueID()).blockPos;
 
-      if (blockPos.equals(breakEvent.getPos())) {
-        treeHandler.destroyTree((World) breakEvent.getWorld(), breakEvent.getPlayer());
-
-        if (!breakEvent.getPlayer().isCreative() && breakEvent.getPlayer().getHeldItemMainhand().isDamageable()) {
-          int axeDurability = breakEvent.getPlayer().getHeldItemMainhand().getDamage() + (int) (playerData.get(breakEvent.getPlayer().getUniqueID()).logCount * 1.5);
-          breakEvent.getPlayer().getHeldItemMainhand().setDamage(axeDurability);
-        }
-      }
-    }
   }
 
   // Check if the block at @blockPos is an instance of LOGS

--- a/src/main/java/treechopper/proxy/ServerProxy.java
+++ b/src/main/java/treechopper/proxy/ServerProxy.java
@@ -7,6 +7,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import treechopper.common.handler.TreeHandler;
+import treechopper.common.tree.Tree;
 import treechopper.core.TreeChopper;
 
 /**
@@ -14,6 +16,7 @@ import treechopper.core.TreeChopper;
  */
 @Mod.EventBusSubscriber(modid = TreeChopper.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.DEDICATED_SERVER)
 public class ServerProxy {
+    private static TreeHandler treeHandler = new TreeHandler();
 
     /**
      * Breaks the wood block, the tree, and damages the axe.
@@ -22,6 +25,13 @@ public class ServerProxy {
      */
     @SubscribeEvent
     public static void destroyWoodBlock(BlockEvent.BreakEvent breakEvent) {
+        BlockPos blockPos = breakEvent.getPos();
+        Tree tree = treeHandler.analyzeTree((World) breakEvent.getWorld(), blockPos, breakEvent.getPlayer());
+        treeHandler.destroyTree((World) breakEvent.getWorld(), tree);
 
+        if (!breakEvent.getPlayer().isCreative() && breakEvent.getPlayer().getHeldItemMainhand().isDamageable()) {
+            int axeDurability = breakEvent.getPlayer().getHeldItemMainhand().getDamage() + (int)(tree.getLogCount() * 1.5);
+            breakEvent.getPlayer().getHeldItemMainhand().setDamage(axeDurability);
+        }
     }
 }

--- a/src/main/java/treechopper/proxy/ServerProxy.java
+++ b/src/main/java/treechopper/proxy/ServerProxy.java
@@ -1,0 +1,27 @@
+package treechopper.proxy;
+
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import treechopper.core.TreeChopper;
+
+/**
+ * Handles all event bus listeners.  Server side only.
+ */
+@Mod.EventBusSubscriber(modid = TreeChopper.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.DEDICATED_SERVER)
+public class ServerProxy {
+
+    /**
+     * Breaks the wood block, the tree, and damages the axe.
+     *
+     * @param breakEvent Event being listened for
+     */
+    @SubscribeEvent
+    public static void destroyWoodBlock(BlockEvent.BreakEvent breakEvent) {
+
+    }
+}

--- a/src/main/java/treechopper/proxy/ServerProxy.java
+++ b/src/main/java/treechopper/proxy/ServerProxy.java
@@ -1,14 +1,10 @@
 package treechopper.proxy;
 
-
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import treechopper.common.handler.TreeHandler;
-import treechopper.common.tree.Tree;
 import treechopper.core.TreeChopper;
 
 /**
@@ -25,13 +21,6 @@ public class ServerProxy {
      */
     @SubscribeEvent
     public static void destroyWoodBlock(BlockEvent.BreakEvent breakEvent) {
-        BlockPos blockPos = breakEvent.getPos();
-        Tree tree = treeHandler.analyzeTree((World) breakEvent.getWorld(), blockPos, breakEvent.getPlayer());
-        treeHandler.destroyTree((World) breakEvent.getWorld(), tree);
-
-        if (!breakEvent.getPlayer().isCreative() && breakEvent.getPlayer().getHeldItemMainhand().isDamageable()) {
-            int axeDurability = breakEvent.getPlayer().getHeldItemMainhand().getDamage() + (int)(tree.getLogCount() * 1.5);
-            breakEvent.getPlayer().getHeldItemMainhand().setDamage(axeDurability);
-        }
+        treeHandler.destroyTreeCommonEvent(breakEvent);
     }
 }


### PR DESCRIPTION
The BreakEvent is now moved to the server side, so single player would work without this PR but multiplayer will not. Though moving the BreakEvent to the server-side-only breaks the single player workflow.  It is necessary to make both sides handle the break event, so in order to not duplicate code, the break event logic was moved to a common location.

In doing so, the playerData pattern had to be augmented, including caching the analyzed tree, breaking out decision logic and making some methods use more common logic.